### PR TITLE
Use argument value for 'mat' in call to format for vector_mat and vector_mat_template

### DIFF
--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -571,8 +571,8 @@ class CppHeaderParser(object):
                     arg_type, arg_name, modlist, argno = self.parse_arg(a, argno)
                     if self.wrap_mode:
                         # TODO: Vectors should contain UMat, but this is not very easy to support and not very needed
-                        vector_mat = "vector_{}".format("Mat")
-                        vector_mat_template = "vector<{}>".format("Mat")
+                        vector_mat = "vector_{}".format(mat)
+                        vector_mat_template = "vector<{}>".format(mat)
 
                         if arg_type == "InputArray":
                             arg_type = mat


### PR DESCRIPTION
The hard-coded string value "Mat" was used in the two format strings for vector_mat and vector_mat_template, preventing UMat arguments to functions that have these types from working correctly. Notably, #12231 references this issue.